### PR TITLE
three changes to pdf-gen

### DIFF
--- a/UTILS/post/pdf-gen-volume.cxx
+++ b/UTILS/post/pdf-gen-volume.cxx
@@ -137,6 +137,10 @@ int main( int argc, char** argv ) {
         TH1D M1_all_1461("M1_all_1461", "ID with edep in range = 1461 +- 4 keV, M=1 (all)",  40, 0, 40);
         TH1D M1_all_full("M1_all_full", "ID with edep in range = [565,5500] keV, M=1 (all)", 40, 0, 40);
 
+        TH1D M1_all_S1  ("M1_all_S1",   "ID with edep in range = [1405,1450] keV, M=1 (all)", 40, 0, 40);
+        TH1D M1_all_S2  ("M1_all_S2",   "ID with edep in range = [1470,1515] keV, M=1 (all)", 40, 0, 40);
+        TH1D M1_all_S3  ("M1_all_S3",   "ID with edep in range = [1535,1580] keV, M=1 (all)", 40, 0, 40);
+
         // build final M2 spectra
         TH2D M2_enrE1vsE2  ("M2_enrE1vsE2",   "edep with smaller detID, other edep, M=2 (enrAll)", 8000, 0, 8000, 8000, 0, 8000);
         TH1D M2_enrE1plusE2("M2_enrE1plusE2", "edep1 + edep2, M=2 (enrAll)",                       8000, 0, 8000);
@@ -184,6 +188,10 @@ int main( int argc, char** argv ) {
             TH1D* tmp_M1_all_1461       = dynamic_cast<TH1D*>(inFile.Get("M1_all_1461"));       if (!tmp_M1_all_1461)                   std::cout << "Problems retrieving M1_all_1461!\n";
             TH1D* tmp_M1_all_full       = dynamic_cast<TH1D*>(inFile.Get("M1_all_full"));       if (!tmp_M1_all_full)                   std::cout << "Problems retrieving M1_all_full!\n";
 
+            TH1D* tmp_M1_all_S1         = dynamic_cast<TH1D*>(inFile.Get("M1_all_S1"));         if (!tmp_M1_all_S1)                     std::cout << "Problems retrieving M1_all_S1!\n";
+            TH1D* tmp_M1_all_S2         = dynamic_cast<TH1D*>(inFile.Get("M1_all_S2"));         if (!tmp_M1_all_S2)                     std::cout << "Problems retrieving M1_all_S2!\n";
+            TH1D* tmp_M1_all_S3         = dynamic_cast<TH1D*>(inFile.Get("M1_all_S3"));         if (!tmp_M1_all_S3)                     std::cout << "Problems retrieving M1_all_S3!\n";
+
             TH2D* tmp_M2_enrE1vsE2      = dynamic_cast<TH2D*>(inFile.Get("M2_enrE1vsE2"));      if (verbose and !tmp_M2_enrE1vsE2)      std::cout << "Problems retrieving M2_enrE1vsE2!\n";
             TH1D* tmp_M2_enrE1plusE2    = dynamic_cast<TH1D*>(inFile.Get("M2_enrE1plusE2"));    if (verbose and !tmp_M2_enrE1plusE2)    std::cout << "Problems retrieving M2_enrE1plusE2!\n";
             TH1D* tmp_M2_enrE1andE2     = dynamic_cast<TH1D*>(inFile.Get("M2_enrE1andE2"));     if (verbose and !tmp_M2_enrE1andE2)     std::cout << "Problems retrieving M2_enrE1andE2!\n";
@@ -222,6 +230,10 @@ int main( int argc, char** argv ) {
             M1_all_1525    .Add(tmp_M1_all_1525);
             M1_all_1461    .Add(tmp_M1_all_1461);
             M1_all_full    .Add(tmp_M1_all_full);
+
+            M1_all_S1      .Add(tmp_M1_all_S1);
+            M1_all_S2      .Add(tmp_M1_all_S2);
+            M1_all_S3      .Add(tmp_M1_all_S3);
 
             if (processCoin) {
                  M2_enrE1vsE2     .Add(tmp_M2_enrE1vsE2);
@@ -263,6 +275,10 @@ int main( int argc, char** argv ) {
         M1_all_1525.Write();
         M1_all_1461.Write();
         M1_all_full.Write();
+
+        M1_all_S1.Write();
+        M1_all_S2.Write();
+        M1_all_S3.Write();
 
         if (processCoin) {
              M2_enrE1vsE2.Write();

--- a/UTILS/post/pdf-gen-volume.cxx
+++ b/UTILS/post/pdf-gen-volume.cxx
@@ -21,8 +21,6 @@
 #include "TFile.h"
 #include "TH1D.h"
 #include "TH2D.h"
-#include "TH1I.h"
-#include "TH2I.h"
 #include "TParameter.h"
 
 int main( int argc, char** argv ) {
@@ -135,28 +133,28 @@ int main( int argc, char** argv ) {
         TH1D energyEnrCoax("M1_enrCoax", "edep, M=1 (enrCOAX)", 8000, 0, 8000);
         TH1D energyNatCoax("M1_natCoax", "edep, M=1 (natCOAX)", 8000, 0, 8000);
 
-        TH1I M1_all_1525("M1_all_1525", "ID with edep in range = 1525 +- 4 keV, M=1 (all)",  40, 0, 40);
-        TH1I M1_all_1461("M1_all_1461", "ID with edep in range = 1461 +- 4 keV, M=1 (all)",  40, 0, 40);
-        TH1I M1_all_full("M1_all_full", "ID with edep in range = [565,5500] keV, M=1 (all)", 40, 0, 40);
+        TH1D M1_all_1525("M1_all_1525", "ID with edep in range = 1525 +- 4 keV, M=1 (all)",  40, 0, 40);
+        TH1D M1_all_1461("M1_all_1461", "ID with edep in range = 1461 +- 4 keV, M=1 (all)",  40, 0, 40);
+        TH1D M1_all_full("M1_all_full", "ID with edep in range = [565,5500] keV, M=1 (all)", 40, 0, 40);
 
         // build final M2 spectra
         TH2D M2_enrE1vsE2  ("M2_enrE1vsE2",   "edep with smaller detID, other edep, M=2 (enrAll)", 8000, 0, 8000, 8000, 0, 8000);
         TH1D M2_enrE1plusE2("M2_enrE1plusE2", "edep1 + edep2, M=2 (enrAll)",                       8000, 0, 8000);
         TH1D M2_enrE1andE2 ("M2_enrE1andE2",  "edep1 and edep2, M=2 (enrAll)",                     8000, 0, 8000);
 
-        TH2I M2_ID1vsID2_1525("M2_ID1vsID2_1525", "ID1 with edep1+edep2 in range = 1525 +- 6 keV, ID2, M=2 (enrAll)",   40, 0, 40, 40, 0, 40);
-        TH2I M2_ID1vsID2_1461("M2_ID1vsID2_1461", "ID1 with edep1+edep2 in range = 1461 +- 6 keV, ID2, M=2 (enrAll)",   40, 0, 40, 40, 0, 40);
-        TH2I M2_ID1vsID2_full("M2_ID1vsID2_full", "ID1 with edep1+edep2 in range = [250,3000] keV, ID2, M=2 (enrAll)",  40, 0, 40, 40, 0, 40);
-        TH2I M2_ID1vsID2_S1  ("M2_ID1vsID2_S1",   "ID1 with edep1+edep2 in range = [1405,1450] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
-        TH2I M2_ID1vsID2_S2  ("M2_ID1vsID2_S2",   "ID1 with edep1+edep2 in range = [1470,1515] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
-        TH2I M2_ID1vsID2_S3  ("M2_ID1vsID2_S3",   "ID1 with edep1+edep2 in range = [1535,1580] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
+        TH2D M2_ID1vsID2_1525("M2_ID1vsID2_1525", "ID1 with edep1+edep2 in range = 1525 +- 6 keV, ID2, M=2 (enrAll)",   40, 0, 40, 40, 0, 40);
+        TH2D M2_ID1vsID2_1461("M2_ID1vsID2_1461", "ID1 with edep1+edep2 in range = 1461 +- 6 keV, ID2, M=2 (enrAll)",   40, 0, 40, 40, 0, 40);
+        TH2D M2_ID1vsID2_full("M2_ID1vsID2_full", "ID1 with edep1+edep2 in range = [250,3000] keV, ID2, M=2 (enrAll)",  40, 0, 40, 40, 0, 40);
+        TH2D M2_ID1vsID2_S1  ("M2_ID1vsID2_S1",   "ID1 with edep1+edep2 in range = [1405,1450] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
+        TH2D M2_ID1vsID2_S2  ("M2_ID1vsID2_S2",   "ID1 with edep1+edep2 in range = [1470,1515] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
+        TH2D M2_ID1vsID2_S3  ("M2_ID1vsID2_S3",   "ID1 with edep1+edep2 in range = [1535,1580] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
 
-        TH1I M2_ID1andID2_1525("M2_ID1andID2_1525", "ID1 and ID2 with edep1+edep2 in range = 1525 +- 6 keV, M=2 (enrAll)",   40, 0, 40);
-        TH1I M2_ID1andID2_1461("M2_ID1andID2_1461", "ID1 and ID2 with edep1+edep2 in range = 1461 +- 6 keV, M=2 (enrAll)",   40, 0, 40);
-        TH1I M2_ID1andID2_full("M2_ID1andID2_full", "ID1 and ID2 with edep1+edep2 in range = [250,3000] keV, M=2 (enrAll)",  40, 0, 40);
-        TH1I M2_ID1andID2_S1  ("M2_ID1andID2_S1",   "ID1 and ID2 with edep1+edep2 in range = [1405,1450] keV, M=2 (enrAll)", 40, 0, 40);
-        TH1I M2_ID1andID2_S2  ("M2_ID1andID2_S2",   "ID1 and ID2 with edep1+edep2 in range = [1470,1515] keV, M=2 (enrAll)", 40, 0, 40);
-        TH1I M2_ID1andID2_S3  ("M2_ID1andID2_S3",   "ID1 and ID2 with edep1+edep2 in range = [1535,1580] keV, M=2 (enrAll)", 40, 0, 40);
+        TH1D M2_ID1andID2_1525("M2_ID1andID2_1525", "ID1 and ID2 with edep1+edep2 in range = 1525 +- 6 keV, M=2 (enrAll)",   40, 0, 40);
+        TH1D M2_ID1andID2_1461("M2_ID1andID2_1461", "ID1 and ID2 with edep1+edep2 in range = 1461 +- 6 keV, M=2 (enrAll)",   40, 0, 40);
+        TH1D M2_ID1andID2_full("M2_ID1andID2_full", "ID1 and ID2 with edep1+edep2 in range = [250,3000] keV, M=2 (enrAll)",  40, 0, 40);
+        TH1D M2_ID1andID2_S1  ("M2_ID1andID2_S1",   "ID1 and ID2 with edep1+edep2 in range = [1405,1450] keV, M=2 (enrAll)", 40, 0, 40);
+        TH1D M2_ID1andID2_S2  ("M2_ID1andID2_S2",   "ID1 and ID2 with edep1+edep2 in range = [1470,1515] keV, M=2 (enrAll)", 40, 0, 40);
+        TH1D M2_ID1andID2_S3  ("M2_ID1andID2_S3",   "ID1 and ID2 with edep1+edep2 in range = [1535,1580] keV, M=2 (enrAll)", 40, 0, 40);
 
         // now loop over parts
         bool missingpdf = false;
@@ -182,26 +180,26 @@ int main( int argc, char** argv ) {
             TH1D* tmp_energyEnrCoax     = dynamic_cast<TH1D*>(inFile.Get("M1_enrCoax"));        if (!tmp_energyEnrCoax)                 std::cout << "Problems retrieving M1_energyEnrCoax!\n";
             TH1D* tmp_energyNatCoax     = dynamic_cast<TH1D*>(inFile.Get("M1_natCoax"));        if (!tmp_energyNatCoax)                 std::cout << "Problems retrieving M1_energyNatCoax!\n";
 
-            TH1I* tmp_M1_all_1525       = dynamic_cast<TH1I*>(inFile.Get("M1_all_1525"));       if (!tmp_M1_all_1525)                   std::cout << "Problems retrieving M1_all_1525!\n";
-            TH1I* tmp_M1_all_1461       = dynamic_cast<TH1I*>(inFile.Get("M1_all_1461"));       if (!tmp_M1_all_1461)                   std::cout << "Problems retrieving M1_all_1461!\n";
-            TH1I* tmp_M1_all_full       = dynamic_cast<TH1I*>(inFile.Get("M1_all_full"));       if (!tmp_M1_all_full)                   std::cout << "Problems retrieving M1_all_full!\n";
+            TH1D* tmp_M1_all_1525       = dynamic_cast<TH1D*>(inFile.Get("M1_all_1525"));       if (!tmp_M1_all_1525)                   std::cout << "Problems retrieving M1_all_1525!\n";
+            TH1D* tmp_M1_all_1461       = dynamic_cast<TH1D*>(inFile.Get("M1_all_1461"));       if (!tmp_M1_all_1461)                   std::cout << "Problems retrieving M1_all_1461!\n";
+            TH1D* tmp_M1_all_full       = dynamic_cast<TH1D*>(inFile.Get("M1_all_full"));       if (!tmp_M1_all_full)                   std::cout << "Problems retrieving M1_all_full!\n";
 
             TH2D* tmp_M2_enrE1vsE2      = dynamic_cast<TH2D*>(inFile.Get("M2_enrE1vsE2"));      if (verbose and !tmp_M2_enrE1vsE2)      std::cout << "Problems retrieving M2_enrE1vsE2!\n";
             TH1D* tmp_M2_enrE1plusE2    = dynamic_cast<TH1D*>(inFile.Get("M2_enrE1plusE2"));    if (verbose and !tmp_M2_enrE1plusE2)    std::cout << "Problems retrieving M2_enrE1plusE2!\n";
             TH1D* tmp_M2_enrE1andE2     = dynamic_cast<TH1D*>(inFile.Get("M2_enrE1andE2"));     if (verbose and !tmp_M2_enrE1andE2)     std::cout << "Problems retrieving M2_enrE1andE2!\n";
-            TH2I* tmp_M2_ID1vsID2_1525  = dynamic_cast<TH2I*>(inFile.Get("M2_ID1vsID2_1525"));  if (verbose and !tmp_M2_ID1vsID2_1525)  std::cout << "Problems retrieving M2_ID1vsID2_1525!\n";
-            TH2I* tmp_M2_ID1vsID2_1461  = dynamic_cast<TH2I*>(inFile.Get("M2_ID1vsID2_1461"));  if (verbose and !tmp_M2_ID1vsID2_1461)  std::cout << "Problems retrieving M2_ID1vsID2_1461!\n";
-            TH2I* tmp_M2_ID1vsID2_full  = dynamic_cast<TH2I*>(inFile.Get("M2_ID1vsID2_full"));  if (verbose and !tmp_M2_ID1vsID2_full)  std::cout << "Problems retrieving M2_ID1vsID2_full!\n";
-            TH2I* tmp_M2_ID1vsID2_S1    = dynamic_cast<TH2I*>(inFile.Get("M2_ID1vsID2_S1"));    if (verbose and !tmp_M2_ID1vsID2_S1)    std::cout << "Problems retrieving M2_ID1vsID2_S1!\n";
-            TH2I* tmp_M2_ID1vsID2_S2    = dynamic_cast<TH2I*>(inFile.Get("M2_ID1vsID2_S2"));    if (verbose and !tmp_M2_ID1vsID2_S2)    std::cout << "Problems retrieving M2_ID1vsID2_S2!\n";
-            TH2I* tmp_M2_ID1vsID2_S3    = dynamic_cast<TH2I*>(inFile.Get("M2_ID1vsID2_S3"));    if (verbose and !tmp_M2_ID1vsID2_S3)    std::cout << "Problems retrieving M2_ID1vsID2_S3!\n";
+            TH2D* tmp_M2_ID1vsID2_1525  = dynamic_cast<TH2D*>(inFile.Get("M2_ID1vsID2_1525"));  if (verbose and !tmp_M2_ID1vsID2_1525)  std::cout << "Problems retrieving M2_ID1vsID2_1525!\n";
+            TH2D* tmp_M2_ID1vsID2_1461  = dynamic_cast<TH2D*>(inFile.Get("M2_ID1vsID2_1461"));  if (verbose and !tmp_M2_ID1vsID2_1461)  std::cout << "Problems retrieving M2_ID1vsID2_1461!\n";
+            TH2D* tmp_M2_ID1vsID2_full  = dynamic_cast<TH2D*>(inFile.Get("M2_ID1vsID2_full"));  if (verbose and !tmp_M2_ID1vsID2_full)  std::cout << "Problems retrieving M2_ID1vsID2_full!\n";
+            TH2D* tmp_M2_ID1vsID2_S1    = dynamic_cast<TH2D*>(inFile.Get("M2_ID1vsID2_S1"));    if (verbose and !tmp_M2_ID1vsID2_S1)    std::cout << "Problems retrieving M2_ID1vsID2_S1!\n";
+            TH2D* tmp_M2_ID1vsID2_S2    = dynamic_cast<TH2D*>(inFile.Get("M2_ID1vsID2_S2"));    if (verbose and !tmp_M2_ID1vsID2_S2)    std::cout << "Problems retrieving M2_ID1vsID2_S2!\n";
+            TH2D* tmp_M2_ID1vsID2_S3    = dynamic_cast<TH2D*>(inFile.Get("M2_ID1vsID2_S3"));    if (verbose and !tmp_M2_ID1vsID2_S3)    std::cout << "Problems retrieving M2_ID1vsID2_S3!\n";
 
-            TH1I* tmp_M2_ID1andID2_1525 = dynamic_cast<TH1I*>(inFile.Get("M2_ID1andID2_1525")); if (verbose and !tmp_M2_ID1andID2_1525) std::cout << "Problems retrieving M2_ID1andID2_1525!\n";
-            TH1I* tmp_M2_ID1andID2_1461 = dynamic_cast<TH1I*>(inFile.Get("M2_ID1andID2_1461")); if (verbose and !tmp_M2_ID1andID2_1461) std::cout << "Problems retrieving M2_ID1andID2_1461!\n";
-            TH1I* tmp_M2_ID1andID2_full = dynamic_cast<TH1I*>(inFile.Get("M2_ID1andID2_full")); if (verbose and !tmp_M2_ID1andID2_full) std::cout << "Problems retrieving M2_ID1andID2_full!\n";
-            TH1I* tmp_M2_ID1andID2_S1   = dynamic_cast<TH1I*>(inFile.Get("M2_ID1andID2_S1"));   if (verbose and !tmp_M2_ID1andID2_S1)   std::cout << "Problems retrieving M2_ID1andID2_S1!\n";
-            TH1I* tmp_M2_ID1andID2_S2   = dynamic_cast<TH1I*>(inFile.Get("M2_ID1andID2_S2"));   if (verbose and !tmp_M2_ID1andID2_S2)   std::cout << "Problems retrieving M2_ID1andID2_S2!\n";
-            TH1I* tmp_M2_ID1andID2_S3   = dynamic_cast<TH1I*>(inFile.Get("M2_ID1andID2_S3"));   if (verbose and !tmp_M2_ID1andID2_S3)   std::cout << "Problems retrieving M2_ID1andID2_S3!\n";
+            TH1D* tmp_M2_ID1andID2_1525 = dynamic_cast<TH1D*>(inFile.Get("M2_ID1andID2_1525")); if (verbose and !tmp_M2_ID1andID2_1525) std::cout << "Problems retrieving M2_ID1andID2_1525!\n";
+            TH1D* tmp_M2_ID1andID2_1461 = dynamic_cast<TH1D*>(inFile.Get("M2_ID1andID2_1461")); if (verbose and !tmp_M2_ID1andID2_1461) std::cout << "Problems retrieving M2_ID1andID2_1461!\n";
+            TH1D* tmp_M2_ID1andID2_full = dynamic_cast<TH1D*>(inFile.Get("M2_ID1andID2_full")); if (verbose and !tmp_M2_ID1andID2_full) std::cout << "Problems retrieving M2_ID1andID2_full!\n";
+            TH1D* tmp_M2_ID1andID2_S1   = dynamic_cast<TH1D*>(inFile.Get("M2_ID1andID2_S1"));   if (verbose and !tmp_M2_ID1andID2_S1)   std::cout << "Problems retrieving M2_ID1andID2_S1!\n";
+            TH1D* tmp_M2_ID1andID2_S2   = dynamic_cast<TH1D*>(inFile.Get("M2_ID1andID2_S2"));   if (verbose and !tmp_M2_ID1andID2_S2)   std::cout << "Problems retrieving M2_ID1andID2_S2!\n";
+            TH1D* tmp_M2_ID1andID2_S3   = dynamic_cast<TH1D*>(inFile.Get("M2_ID1andID2_S3"));   if (verbose and !tmp_M2_ID1andID2_S3)   std::cout << "Problems retrieving M2_ID1andID2_S3!\n";
 
             if (inFile.GetListOfKeys()->Contains("NumberOfPrimariesCoin")) {
                 nPrimCoin += dynamic_cast<TParameter<long>*>(inFile.Get("NumberOfPrimariesCoin"))->GetVal();

--- a/UTILS/post/pdf-gen.cxx
+++ b/UTILS/post/pdf-gen.cxx
@@ -137,6 +137,10 @@ int main( int argc, char** argv ) {
     TH1D M1_all_1461("M1_all_1461", "ID with edep in range = 1461 +- 4 keV, M=1 (all)",  40, 0, 40);
     TH1D M1_all_full("M1_all_full", "ID with edep in range = [565,5500] keV, M=1 (all)", 40, 0, 40);
 
+    TH1D M1_all_S1  ("M1_all_S1",   "ID with edep in range = [1405,1450] keV, M=1 (all)", 40, 0, 40);
+    TH1D M1_all_S2  ("M1_all_S2",   "ID with edep in range = [1470,1515] keV, M=1 (all)", 40, 0, 40);
+    TH1D M1_all_S3  ("M1_all_S3",   "ID with edep in range = [1535,1580] keV, M=1 (all)", 40, 0, 40);
+
     // set up the TTree reader object
     TTreeReader reader;
     TTreeReaderValue<int>    multiplicity(reader, "multiplicity");
@@ -157,6 +161,9 @@ int main( int argc, char** argv ) {
                     if ( energy[i] >= 1521 and energy[i] < 1529 ) M1_all_1525.Fill(i);
                     if ( energy[i] >= 1457 and energy[i] < 1465 ) M1_all_1461.Fill(i);
                     if ( energy[i] >= 565  and energy[i] < 5500 ) M1_all_full.Fill(i);
+                    if ( energy[i] >= 1405 and energy[i] < 1450 ) M1_all_S1.Fill(i);
+                    if ( energy[i] >= 1470 and energy[i] < 1515 ) M1_all_S2.Fill(i);
+                    if ( energy[i] >= 1535 and energy[i] < 1580 ) M1_all_S3.Fill(i);
                     if ( det[i].substr(0,2) == "GD"  ) energyBEGe.Fill(energy[i]);
                     if ( det[i].substr(0,3) == "ANG" or
                          det[i].substr(0,2) == "RG"  ) energyEnrCoax.Fill(energy[i]);
@@ -312,6 +319,10 @@ int main( int argc, char** argv ) {
     M1_all_1525.Write();
     M1_all_1461.Write();
     M1_all_full.Write();
+
+    M1_all_S1.Write();
+    M1_all_S2.Write();
+    M1_all_S3.Write();
 
     if (processCoin) {
         M2_enrE1vsE2.Write();

--- a/UTILS/post/pdf-gen.cxx
+++ b/UTILS/post/pdf-gen.cxx
@@ -24,8 +24,6 @@
 #include "TTreeReaderValue.h"
 #include "TH1D.h"
 #include "TH2D.h"
-#include "TH1I.h"
-#include "TH2I.h"
 #include "TString.h"
 #include "TParameter.h"
 #include "TChain.h"
@@ -135,9 +133,9 @@ int main( int argc, char** argv ) {
     TH1D energyEnrCoax("M1_enrCoax", "edep, M=1 (enrCOAX)", 8000, 0, 8000);
     TH1D energyNatCoax("M1_natCoax", "edep, M=1 (natCOAX)", 8000, 0, 8000);
 
-    TH1I M1_all_1525("M1_all_1525", "ID with edep in range = 1525 +- 4 keV, M=1 (all)",  40, 0, 40);
-    TH1I M1_all_1461("M1_all_1461", "ID with edep in range = 1461 +- 4 keV, M=1 (all)",  40, 0, 40);
-    TH1I M1_all_full("M1_all_full", "ID with edep in range = [565,5500] keV, M=1 (all)", 40, 0, 40);
+    TH1D M1_all_1525("M1_all_1525", "ID with edep in range = 1525 +- 4 keV, M=1 (all)",  40, 0, 40);
+    TH1D M1_all_1461("M1_all_1461", "ID with edep in range = 1461 +- 4 keV, M=1 (all)",  40, 0, 40);
+    TH1D M1_all_full("M1_all_full", "ID with edep in range = [565,5500] keV, M=1 (all)", 40, 0, 40);
 
     // set up the TTree reader object
     TTreeReader reader;
@@ -192,19 +190,19 @@ int main( int argc, char** argv ) {
     TH1D M2_enrE1plusE2("M2_enrE1plusE2", "edep1 + edep2, M=2 (enrAll)",                       8000, 0, 8000);
     TH1D M2_enrE1andE2 ("M2_enrE1andE2",  "edep1 and edep2, M=2 (enrAll)",                     8000, 0, 8000);
 
-    TH2I M2_ID1vsID2_1525("M2_ID1vsID2_1525", "ID1 with edep1+edep2 in range = 1525 +- 6 keV, ID2, M=2 (enrAll)",   40, 0, 40, 40, 0, 40);
-    TH2I M2_ID1vsID2_1461("M2_ID1vsID2_1461", "ID1 with edep1+edep2 in range = 1461 +- 6 keV, ID2, M=2 (enrAll)",   40, 0, 40, 40, 0, 40);
-    TH2I M2_ID1vsID2_full("M2_ID1vsID2_full", "ID1 with edep1+edep2 in range = [250,3000] keV, ID2, M=2 (enrAll)",  40, 0, 40, 40, 0, 40);
-    TH2I M2_ID1vsID2_S1  ("M2_ID1vsID2_S1",   "ID1 with edep1+edep2 in range = [1405,1450] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
-    TH2I M2_ID1vsID2_S2  ("M2_ID1vsID2_S2",   "ID1 with edep1+edep2 in range = [1470,1515] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
-    TH2I M2_ID1vsID2_S3  ("M2_ID1vsID2_S3",   "ID1 with edep1+edep2 in range = [1535,1580] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
+    TH2D M2_ID1vsID2_1525("M2_ID1vsID2_1525", "ID1 with edep1+edep2 in range = 1525 +- 6 keV, ID2, M=2 (enrAll)",   40, 0, 40, 40, 0, 40);
+    TH2D M2_ID1vsID2_1461("M2_ID1vsID2_1461", "ID1 with edep1+edep2 in range = 1461 +- 6 keV, ID2, M=2 (enrAll)",   40, 0, 40, 40, 0, 40);
+    TH2D M2_ID1vsID2_full("M2_ID1vsID2_full", "ID1 with edep1+edep2 in range = [250,3000] keV, ID2, M=2 (enrAll)",  40, 0, 40, 40, 0, 40);
+    TH2D M2_ID1vsID2_S1  ("M2_ID1vsID2_S1",   "ID1 with edep1+edep2 in range = [1405,1450] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
+    TH2D M2_ID1vsID2_S2  ("M2_ID1vsID2_S2",   "ID1 with edep1+edep2 in range = [1470,1515] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
+    TH2D M2_ID1vsID2_S3  ("M2_ID1vsID2_S3",   "ID1 with edep1+edep2 in range = [1535,1580] keV, ID2, M=2 (enrAll)", 40, 0, 40, 40, 0, 40);
 
-    TH1I M2_ID1andID2_1525("M2_ID1andID2_1525", "ID1 and ID2 with edep1+edep2 in range = 1525 +- 6 keV, M=2 (enrAll)",   40, 0, 40);
-    TH1I M2_ID1andID2_1461("M2_ID1andID2_1461", "ID1 and ID2 with edep1+edep2 in range = 1461 +- 6 keV, M=2 (enrAll)",   40, 0, 40);
-    TH1I M2_ID1andID2_full("M2_ID1andID2_full", "ID1 and ID2 with edep1+edep2 in range = [250,3000] keV, M=2 (enrAll)",  40, 0, 40);
-    TH1I M2_ID1andID2_S1  ("M2_ID1andID2_S1",   "ID1 and ID2 with edep1+edep2 in range = [1405,1450] keV, M=2 (enrAll)", 40, 0, 40);
-    TH1I M2_ID1andID2_S2  ("M2_ID1andID2_S2",   "ID1 and ID2 with edep1+edep2 in range = [1470,1515] keV, M=2 (enrAll)", 40, 0, 40);
-    TH1I M2_ID1andID2_S3  ("M2_ID1andID2_S3",   "ID1 and ID2 with edep1+edep2 in range = [1535,1580] keV, M=2 (enrAll)", 40, 0, 40);
+    TH1D M2_ID1andID2_1525("M2_ID1andID2_1525", "ID1 and ID2 with edep1+edep2 in range = 1525 +- 6 keV, M=2 (enrAll)",   40, 0, 40);
+    TH1D M2_ID1andID2_1461("M2_ID1andID2_1461", "ID1 and ID2 with edep1+edep2 in range = 1461 +- 6 keV, M=2 (enrAll)",   40, 0, 40);
+    TH1D M2_ID1andID2_full("M2_ID1andID2_full", "ID1 and ID2 with edep1+edep2 in range = [250,3000] keV, M=2 (enrAll)",  40, 0, 40);
+    TH1D M2_ID1andID2_S1  ("M2_ID1andID2_S1",   "ID1 and ID2 with edep1+edep2 in range = [1405,1450] keV, M=2 (enrAll)", 40, 0, 40);
+    TH1D M2_ID1andID2_S2  ("M2_ID1andID2_S2",   "ID1 and ID2 with edep1+edep2 in range = [1470,1515] keV, M=2 (enrAll)", 40, 0, 40);
+    TH1D M2_ID1andID2_S3  ("M2_ID1andID2_S3",   "ID1 and ID2 with edep1+edep2 in range = [1535,1580] keV, M=2 (enrAll)", 40, 0, 40);
 
     long nPrimCoin = 0;  // number of primaries for coincidences
     int badevents = 0;   // counter for events with multiplicity 2 but only 0 or 1 energy deposition

--- a/UTILS/post/pdf-gen.cxx
+++ b/UTILS/post/pdf-gen.cxx
@@ -243,7 +243,11 @@ int main( int argc, char** argv ) {
                 std::cout << ID1 << '\t' << E1 << std::endl;
                 std::cout << ID2 << '\t' << E2 << std::endl;
                 std::cout << "-------------\n";
-*/                auto sumE = E1 + E2;
+*/
+                //do not include events that contain a trigger in an AC channel
+                if(E1==10000||E2==10000) continue;
+
+                auto sumE = E1 + E2;
                 if ( det[ID1].substr(0,3) != "GTF" and
                      det[ID2].substr(0,3) != "GTF" ) {
                     M2_enrE1vsE2.Fill(E1, E2);


### PR DESCRIPTION
3 changes:

a) went from TH[12]I to TH[12]D for the detID histograms

the "I" refers to the bin content (and not the x-axis), therefore scaling the histograms with the 1./nPrimaries resulted in 0 bin content

b) added Sideband histograms for M1 data

c) removed M2 events with one trigger in an AC channel

e.g. E1=10000, E2=500 --> multiplicity=2.
This only affects the E1andE2 histograms, to which E2 (in this case) would have been added to (while E1 is out of range).
For the other histograms, such events would have already been excluded, because sumE is out of range.